### PR TITLE
Fix actual return type of date Cli parameter

### DIFF
--- a/simpletasks/cli.py
+++ b/simpletasks/cli.py
@@ -31,8 +31,8 @@ class CliParams:
             return None
 
         try:
-            date = datetime.datetime.strptime(value, "%Y-%m-%d")
-            return date
+            dt = datetime.datetime.strptime(value, "%Y-%m-%d")
+            return dt.date()
         except ValueError:
             raise click.BadParameter("timestamp must be in format YYYY-MM-DD")
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -85,7 +85,9 @@ def test_date(configure) -> None:
     )
     class DateTask(Task):
         def do(self) -> None:
-            click.echo(self.date.strftime("%Y-%m-%d") if self.date else "None")
+            assert self.date is not None
+            assert type(self.date) == datetime.date
+            click.echo(self.date.strftime("%Y-%m-%d"))
 
     runner = CliRunner()
     result = runner.invoke(cli, ["date", "--date", "2020-01-01"])
@@ -94,7 +96,7 @@ def test_date(configure) -> None:
 
     result = runner.invoke(cli, ["date"])
     assert result.exit_code == 0
-    assert result.output == "{:%Y-%m-%d}\n".format(datetime.datetime.today())
+    assert result.output == "{:%Y-%m-%d}\n".format(datetime.date.today())
 
     result = runner.invoke(cli, ["date", "--date", "invalid-date"])
     assert result.exit_code == 2


### PR DESCRIPTION
Signature says it should return an instance of `datetime.date`, but actual return type was `datetime.datetime`. Not incorrect (because `datetime` inherits from `date`), but confusing.
This fixes the return type.